### PR TITLE
Updates for JAGS 5.0.0

### DIFF
--- a/R/get_formula.R
+++ b/R/get_formula.R
@@ -152,7 +152,7 @@ get_formula_str = function(ST, par_x, ytype = "ct", init = FALSE) {
       if (ytype == "ct") {
         formula_str = paste0(formula_str, "\n\n# Fitted value\ny_[i_] = \n")
       } else if (ytype == "sigma") {
-        formula_str = paste0(formula_str, "# Fitted standard deviation\nsigma_[i_] = max(0, \n")  # Add max(0, [formula]) to prevent modeling negative sigmas. JAGS uses precision = 1 / sigma^2 which yields positive precisions for negative sigmas.
+        formula_str = paste0(formula_str, "# Fitted standard deviation\nsigma_[i_] = max(0.001, \n")  # Add max(0, [formula]) to prevent modeling negative sigmas. JAGS uses precision = 1 / sigma^2 which yields positive precisions for negative sigmas.
       } else if (stringr::str_detect(ytype, "ar[0-9]+")) {
         formula_str = paste0(formula_str, "# Autoregressive coefficient for all AR(", ar_order,")\n", ytype, "_[i_] = \n")
       } else if (stringr::str_detect(ytype, "ma[0-9]+")) {

--- a/R/get_jagscode.R
+++ b/R/get_jagscode.R
@@ -145,7 +145,9 @@ get_jagscode = function(prior, ST, formula_str, arma_order, family, sample) {
   # Compute residuals for AR
   if (has_ar) {
     if (family$family == "binomial") {
-      mm = paste0(mm, "\n    resid_abs_[i_] = ", family$linkfun_str, "(", ST$y[1], "[i_] / ", ST$trials[1], "[i_]) - y_[i_]  # Residuals represented by sigma_ after ARMA")
+      mm = paste0(mm, "\n    resid_abs_[i_] = ", family$linkfun_str, "(0.01 + 0.98 * ", ST$y[1], "[i_] / ", ST$trials[1], "[i_]) - y_[i_]  # Residuals represented by sigma_ after ARMA")
+    } else if (family$family == "poisson") {
+      mm = paste0(mm, "\n    resid_abs_[i_] = ", family$linkfun_str, "(0.01 +  ", ST$y[1], "[i_]) - y_[i_]  # Residuals represented by sigma_ after ARMA")
     } else {
       mm = paste0(mm, "\n    resid_abs_[i_] = ", family$linkfun_str, "(", ST$y[1], "[i_])  - y_[i_]  # Residuals represented by sigma_ after ARMA")
     }

--- a/tests/testthat/helper-runs.R
+++ b/tests/testthat/helper-runs.R
@@ -162,14 +162,14 @@ test_plot = function(fit, varying_cols) {
     is_expected = any(stringr::str_detect(error_message, expected_error))
     expect_true(is_expected)
   } else {
-    testthat::expect_true(ggplot2::is.ggplot(gg))
+    testthat::expect_true(ggplot2::is_ggplot(gg))
   }
 }
 
 # Test plot() calls to bayesplot
 test_plot_pars = function(fit) {
   gg = plot_pars(fit, type = "dens_overlay")
-  testthat::expect_true(ggplot2::is.ggplot(gg))
+  testthat::expect_true(ggplot2::is_ggplot(gg))
 }
 
 
@@ -194,7 +194,7 @@ test_hypothesis = function(fit) {
 
   # Varying
   if (!is.null(fit$pars$varying)) {
-    mcmc_vars = colnames(mcmclist_samples(fit)[[1]])
+    mcmc_vars = colnames(mcp:::mcmclist_samples(fit)[[1]])
     varying_starts = paste0("^", fit$pars$varying[1])
     varying_col_ids = stringr::str_detect(mcmc_vars, varying_starts)
     varying_cols = paste0("`", mcmc_vars[varying_col_ids], "`")  # Add these for varying
@@ -298,7 +298,7 @@ test_pp_eval = function(fit) {
       testthat::expect_true(error_message)
     }
   } else {
-    testthat::expect_true(ggplot2::is.ggplot(pp_default))
+    testthat::expect_true(ggplot2::is_ggplot(pp_default))
   }
 }
 


### PR DESCRIPTION
Changes to initial values in JAGS 5.0.0 have revealed issues with some models in mcp. These issues were always present but hidden by the deterministic starting values in previous versions of JAGS.

For autoregressive Poisson and binomial models, the use of the link function to calculate residuals on the scale of the linear predictor leads to numerical overflow when the outcome variable is on the boundary (i.e. y=0 for binomial and Poisson, and y=m for binomial, where m is the size parameter). I've added a small amount of shrinkage away from the boundary. This prevents numerical overflow but I suspect that there will still be statistical problems. I don't have enough experience with autoregressive GLMs to make a better suggestion, but I think there is a case for using Pearson residuals and not trying to work on the scale of the linear predictor. I leave that in your hands.

The reason this was never a problem before is twofold. Firstly the model was always initialized with a an autoregression coefficient of zero. Secondly, JAGS does not use IEEE754 arithmetic so that 0 * Inf = 0. This behaviour (copied from BUGS) means the numerical overflow of the residuals was ignored.

I also found that I had to initialize some random effects standard deviation to a small positive value. 

Finally, to get the package to pass R CMD check, I made some changes for updates in the ggplot2 package (is.plot -> is_plot). 